### PR TITLE
Make audioContext and isTalking public

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export interface StartConversationConfig {
 
 export class RetellWebClient extends EventEmitter {
   private liveClient: AudioWsClient;
-  private audioContext: AudioContext;
+  public audioContext: AudioContext;
   private isCalling: boolean = false;
   private stream: MediaStream;
 
@@ -28,7 +28,7 @@ export class RetellWebClient extends EventEmitter {
   private captureNode: ScriptProcessorNode | null = null;
   private audioData: Float32Array[] = [];
   private audioDataIndex: number = 0;
-  private isTalking: boolean = false;
+  public isTalking: boolean = false;
 
   constructor(customEndpoint?: string) {
     super();


### PR DESCRIPTION
I propose making these two member variables public because:
- Frontend devs may want to attach an Analyser Node to the audioContext to make a [visualizer of the microphone / audio levels](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API)
- Similarly, devs may want to modify the style of their application depending on whether isTalking is true or not