### PR TITLE
Add setting optional custom sink id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export interface StartConversationConfig {
   callId: string;
   sampleRate: number;
   customStream?: MediaStream;
+  customSinkId?: string;
   enableUpdate?: boolean;
 }
 
@@ -43,6 +44,7 @@ export class RetellWebClient extends EventEmitter {
       await this.setupAudioPlayback(
         startConversationConfig.sampleRate,
         startConversationConfig.customStream,
+        startConversationConfig.customSinkId,
       );
       this.liveClient = new AudioWsClient({
         callId: startConversationConfig.callId,
@@ -140,6 +142,7 @@ export class RetellWebClient extends EventEmitter {
   private async setupAudioPlayback(
     sampleRate: number,
     customStream?: MediaStream,
+    customSinkId?: string,
   ): Promise<void> {
     this.audioContext = new AudioContext({ sampleRate: sampleRate });
     try {
@@ -158,6 +161,9 @@ export class RetellWebClient extends EventEmitter {
     }
 
     if (this.isAudioWorkletSupported()) {
+      if (customSinkId) {
+        (this.audioContext as any).setSinkId(customSinkId);
+      }
       console.log("Audio worklet starting");
       this.audioContext.resume();
       const blob = new Blob([workletCode], { type: "application/javascript" });


### PR DESCRIPTION
In this PR, I added a `customSinkId` prop. 
The `customSinkId` passed corresponds to the device on which the user wants their sound to be output. 
If left undefined, existing behaviour still applies, if not, we set the audio context's sink id to the `customSinkId` prop by leveraging AudioContext [setSinkId](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/setSinkId) method. 

This method however is not typed, possibly due to the [browser compatibility](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/setSinkId#browser_compatibility) issues. So the AudioContext needs to be casted as any in order to avoid a TS error, and we use this method within the check `isAudioWorkletSupported` to work around the browser compatibility issues. 

